### PR TITLE
test-eptri: use address 0 for transfers

### DIFF
--- a/tests/test-eptri.py
+++ b/tests/test-eptri.py
@@ -567,10 +567,9 @@ def test_control_transfer_in_out(dut):
 
     yield harness.clear_pending(EndpointType.epaddr(0, EndpointType.OUT))
     yield harness.clear_pending(EndpointType.epaddr(0, EndpointType.IN))
-    yield harness.write(harness.csrs['usb_address'], 20)
 
     yield harness.control_transfer_in(
-        20,
+        0,
         # Get device descriptor
         [0x80, 0x06, 0x00, 0x01, 0x00, 0x00, 0x40, 00],
         # 18 byte descriptor, max packet size 8 bytes
@@ -581,7 +580,7 @@ def test_control_transfer_in_out(dut):
     )
 
     yield harness.control_transfer_out(
-        20,
+        0,
         # Set address (to 11)
         [0x00, 0x05, 0x0B, 0x00, 0x00, 0x00, 0x00, 0x00],
         # 18 byte descriptor, max packet size 8 bytes


### PR DESCRIPTION
Due to a bug in iverilog, writes to wishbone are ignored towards the
start of the simulation. The signals can be seen, but for whatever
reason the registers simply are not updated.

As the simulation progresses, this limitation goes away.

The `test_control_transfer_in_out` test starts out by setting
`usb_address` to `20`, and proceeds to communicate with the device as if
this were its address.

However, due to this iverilog bug, this address is ignored and the
device address remains at 0.

This is not an issue so long as `test_control_transfer_in_out` is not
run in isolation, and is not the first test to be run. However, if this
test is run by itself, it will fail.

Leave the host address as 0. This ensures that it can pass even when run
in isolation.

Signed-off-by: Sean Cross <sean@xobs.io>