### PR TITLE
Valentyusb cdc

### DIFF
--- a/tests/test-eptri.py
+++ b/tests/test-eptri.py
@@ -378,7 +378,7 @@ def test_control_transfer_in_nak_data(dut):
     yield harness.reset()
     yield harness.connect()
 
-    addr = 22
+    addr = 0
     yield harness.write(harness.csrs['usb_address'], addr)
     # Get descriptor, Index 0, Type 03, LangId 0000, wLength 64
     setup_data = [0x80, 0x06, 0x00, 0x03, 0x00, 0x00, 0x40, 0x00]
@@ -767,7 +767,7 @@ def test_debug_in(dut):
     yield harness.reset()
     yield harness.connect()
 
-    addr = 28
+    addr = 0
     yield harness.write(harness.csrs['usb_address'], addr)
     # The "scratch" register defaults to 0x12345678 at boot.
     reg_addr = harness.csrs['ctrl_scratch']
@@ -843,7 +843,7 @@ def test_debug_out(dut):
     yield harness.reset()
     yield harness.connect()
 
-    addr = 28
+    addr = 0
     yield harness.write(harness.csrs['usb_address'], addr)
     reg_addr = harness.csrs['ctrl_scratch']
     setup_data = [

--- a/tests/test-eptri.py
+++ b/tests/test-eptri.py
@@ -497,6 +497,11 @@ def test_control_transfer_in(dut):
                           "was: {:02x}".format(out_ev))
     yield harness.transaction_status_out(ADDR, epaddr_out)
     yield RisingEdge(harness.dut.clk12)
+
+    # give two cycles to percolate through multiregs and event manager
+    yield RisingEdge(harness.dut.clk12)
+    yield RisingEdge(harness.dut.clk12)
+
     out_ev = yield harness.read(harness.csrs['usb_out_ev_pending'])
     if out_ev != 1:
         raise TestFailure("i: out_ev should be 1 at the end of the test, "
@@ -557,6 +562,8 @@ def test_control_transfer_out(dut):
     yield RisingEdge(harness.dut.clk12)
     yield RisingEdge(harness.dut.clk12)
     yield harness.write(harness.csrs['usb_in_ctrl'], 1 << 5)  # Reset IN buffer
+    yield RisingEdge(harness.dut.clk12)
+    yield RisingEdge(harness.dut.clk12)
 
 
 @cocotb.test()
@@ -719,6 +726,8 @@ def test_in_transfer(dut):
     d = [0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8]
 
     yield harness.clear_pending(epaddr)
+    yield RisingEdge(harness.dut.clk12)
+    yield RisingEdge(harness.dut.clk12)
     yield harness.set_response(epaddr, EndpointResponse.NAK)
 
     yield harness.set_data(epaddr, d[:4])

--- a/wrappers/Makefile.valentyusb
+++ b/wrappers/Makefile.valentyusb
@@ -1,3 +1,10 @@
-TARGET_OPTIONS = "eptri"
 PYTHONPATH = ../litex:../valentyusb
 export DUT_CSRS = csr.csv
+
+ifeq ($(CDC),1)
+TARGET_OPTIONS = --cdc eptri
+export TEST_CDC = 1
+else
+TARGET_OPTIONS = eptri
+export TEST_CDC = 0
+endif

--- a/wrappers/generate_valentyusb.py
+++ b/wrappers/generate_valentyusb.py
@@ -41,7 +41,7 @@ _io = [
         0,
         Subsignal("clk48", Pins(1)),
         Subsignal("clk12", Pins(1)),
-        Subsignal("clk100", Pins(1)),
+        Subsignal("clksys", Pins(1)),
     ),
     ("reset", 0, Pins(1)),
 ]
@@ -72,11 +72,10 @@ class _CRG(Module):
 
         self.comb += clk12.eq(clk12_counter[1])
 
-        clk100 = clk.clk100
-        if cdc: # set to true to run with 100 MHz sim
-           self.comb += self.cd_sys.clk.eq(clk100)
+        if cdc:
+            self.comb += self.cd_sys.clk.eq(clk.clksys)
         else:
-           self.comb += self.cd_sys.clk.eq(clk12)
+            self.comb += self.cd_sys.clk.eq(clk12)
 
         self.comb += self.cd_usb_12.clk.eq(clk12)
 

--- a/wrappers/generate_valentyusb.py
+++ b/wrappers/generate_valentyusb.py
@@ -266,12 +266,13 @@ def add_fsm_state_names():
     fsm.FSM._lower_controls = my_lower_controls
 
 
-def generate(output_dir, csr_csv, variant):
+def generate(output_dir, csr_csv, cdc, variant):
     platform = Platform()
     soc = BaseSoC(platform,
                   usb_variant=variant,
                   cpu_type=None,
                   cpu_variant=None,
+                  cdc=cdc,
                   output_dir=output_dir)
     builder = Builder(soc,
                       output_dir=output_dir,
@@ -298,10 +299,13 @@ def main():
                         metavar='CSR',
                         default='csr.csv',
                         help='csr file (default: %(default)s)')
+    parser.add_argument('--cdc',
+                        action='store_true',
+                        help='Add a fast clock domain to sys for CDC testing')
     args = parser.parse_args()
     add_fsm_state_names()
     output_dir = args.dir
-    generate(output_dir, args.csr, args.variant)
+    generate(output_dir, args.csr, args.cdc, args.variant)
 
     print("""Simulation build complete.  Output files:
     {}/gateware/dut.v               Source Verilog file. Run this under Cocotb.

--- a/wrappers/tb_valentyusb.v
+++ b/wrappers/tb_valentyusb.v
@@ -4,6 +4,7 @@ module tb(
 	input clk48_host,
 	input clk48_device,
 	output clk12,
+	input clk100,
 	input reset,
 	inout usb_d_p,
 	inout usb_d_n,
@@ -31,6 +32,7 @@ pulldown(usb_d_p);
 dut dut (
 	.clk_clk48(clk48_device),
 	.clk_clk12(clk12),
+	.clk_clk100(clk100),
 	.reset(reset),
 	.usb_d_p(usb_d_p),
 	.usb_d_n(usb_d_n),

--- a/wrappers/tb_valentyusb.v
+++ b/wrappers/tb_valentyusb.v
@@ -4,7 +4,7 @@ module tb(
 	input clk48_host,
 	input clk48_device,
 	output clk12,
-	input clk100,
+	input clksys,
 	input reset,
 	inout usb_d_p,
 	inout usb_d_n,
@@ -32,7 +32,7 @@ pulldown(usb_d_p);
 dut dut (
 	.clk_clk48(clk48_device),
 	.clk_clk12(clk12),
-	.clk_clk100(clk100),
+	.clk_clksys(clksys),
 	.reset(reset),
 	.usb_d_p(usb_d_p),
 	.usb_d_n(usb_d_n),


### PR DESCRIPTION
This adds a new Makefile parameter `CDC=1` to valentyusb. When this is enabled, it will generate a top file with `sys` broken out into its own clock signal, nominally 100 MHz.

This enables testing valentyusb against platforms that have sys running at a different frequency.

Note that the file does NOT get regenerated when the `CDC` environment variable is changed -- users must remove the `dut.v` file manually.