### PR TITLE
wrappers: have valentyusb generate `dut.v`

### DIFF
--- a/tests/test-eptri.py
+++ b/tests/test-eptri.py
@@ -743,10 +743,10 @@ def test_in_transfer(dut):
 
     # need to wait 3 clk12 cycles after packet received for
     # rx packet machine to reset
-    yield RisingEdge(harness.dut.clk12) 
     yield RisingEdge(harness.dut.clk12)
     yield RisingEdge(harness.dut.clk12)
-    
+    yield RisingEdge(harness.dut.clk12)
+
     yield harness.set_data(epaddr, d[4:])
     yield harness.set_response(epaddr, EndpointResponse.ACK)
 

--- a/tests/test-eptri.py
+++ b/tests/test-eptri.py
@@ -741,7 +741,8 @@ def test_in_transfer(dut):
     if pending:
         raise TestFailure("data was still pending")
 
-    # need to wait 3 clk12 cycles after packet received for rx packet machine to reset    
+    # need to wait 3 clk12 cycles after packet received for
+    # rx packet machine to reset
     yield RisingEdge(harness.dut.clk12) 
     yield RisingEdge(harness.dut.clk12)
     yield RisingEdge(harness.dut.clk12)

--- a/tests/test-eptri.py
+++ b/tests/test-eptri.py
@@ -740,6 +740,12 @@ def test_in_transfer(dut):
     pending = yield harness.pending(epaddr)
     if pending:
         raise TestFailure("data was still pending")
+
+    # need to wait 3 clk12 cycles after packet received for rx packet machine to reset    
+    yield RisingEdge(harness.dut.clk12) 
+    yield RisingEdge(harness.dut.clk12)
+    yield RisingEdge(harness.dut.clk12)
+    
     yield harness.set_data(epaddr, d[4:])
     yield harness.set_response(epaddr, EndpointResponse.ACK)
 

--- a/wrappers/generate_valentyusb.py
+++ b/wrappers/generate_valentyusb.py
@@ -277,7 +277,7 @@ def generate(output_dir, csr_csv, cdc, variant):
                       output_dir=output_dir,
                       csr_csv=csr_csv,
                       compile_software=False)
-    vns = builder.build(run=False)
+    vns = builder.build(run=False, build_name="dut")
     soc.do_exit(vns)
 
 


### PR DESCRIPTION
Something changed in upstream litex. Now we must specify the filename as
an argument to `build()`.

Specify `dut` as the `build_name` in order to keep the rest of the
testsuite working as it was.

This change may need to be replicated across other platforms.