### PR TITLE
valentyusb: pass cdc value to USB objects

### DIFF
--- a/wrappers/generate_valentyusb.py
+++ b/wrappers/generate_valentyusb.py
@@ -170,12 +170,13 @@ class BaseSoC(SoCCore):
         self.comb += usb_pads.tx_en.eq(usb_iobuf.usb_tx_en)
         if usb_variant == 'eptri':
             self.submodules.usb = eptri.TriEndpointInterface(usb_iobuf,
-                                                             debug=True)
+                                                             debug=True,
+                                                             cdc=cdc)
         elif usb_variant == 'epfifo':
             self.submodules.usb = epfifo.PerEndpointFifoInterface(usb_iobuf,
                                                                   debug=True)
         elif usb_variant == 'dummy':
-            self.submodules.usb = dummyusb.DummyUsb(usb_iobuf, debug=True)
+            self.submodules.usb = dummyusb.DummyUsb(usb_iobuf, debug=True, cdc=cdc)
         else:
             raise ValueError(
                 'Invalid endpoints value. It is currently \'eptri\'\

--- a/wrappers/generate_valentyusb.py
+++ b/wrappers/generate_valentyusb.py
@@ -176,7 +176,9 @@ class BaseSoC(SoCCore):
             self.submodules.usb = epfifo.PerEndpointFifoInterface(usb_iobuf,
                                                                   debug=True)
         elif usb_variant == 'dummy':
-            self.submodules.usb = dummyusb.DummyUsb(usb_iobuf, debug=True, cdc=cdc)
+            self.submodules.usb = dummyusb.DummyUsb(usb_iobuf,
+                                                    debug=True,
+                                                    cdc=cdc)
         else:
             raise ValueError(
                 'Invalid endpoints value. It is currently \'eptri\'\


### PR DESCRIPTION
Pass the `cdc` value to the USB cores that are instantiated.

This resolves https://github.com/im-tomu/valentyusb/issues/14 and supersedes https://github.com/antmicro/usb-test-suite-testbenches/pull/19 by @bunnie 